### PR TITLE
Models

### DIFF
--- a/Pool.xcodeproj/project.pbxproj
+++ b/Pool.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		61D934A62702A08E00AD042C /* DataEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D934A52702A08E00AD042C /* DataEntryView.swift */; };
 		E50F155F2750B970005D1774 /* sports.jpg in Resources */ = {isa = PBXBuildFile; fileRef = E50F155E2750B970005D1774 /* sports.jpg */; };
 		E50F15612750B976005D1774 /* sports2.jpg in Resources */ = {isa = PBXBuildFile; fileRef = E50F15602750B976005D1774 /* sports2.jpg */; };
+		E557A56F275B505E007644FD /* WeeklyCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = E557A56E275B505E007644FD /* WeeklyCard.swift */; };
+		E557A571275B580D007644FD /* Team.swift in Sources */ = {isa = PBXBuildFile; fileRef = E557A570275B580D007644FD /* Team.swift */; };
 		E5B40D4326F4302E003DD41A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B40D4226F4302E003DD41A /* AppDelegate.swift */; };
 		E5B40D4526F4302E003DD41A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B40D4426F4302E003DD41A /* SceneDelegate.swift */; };
 		E5B40D4726F4302E003DD41A /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B40D4626F4302E003DD41A /* ViewController.swift */; };
@@ -21,7 +23,7 @@
 		E5B40D5A26F43030003DD41A /* PoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B40D5926F43030003DD41A /* PoolTests.swift */; };
 		E5B40D6526F43030003DD41A /* PoolUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B40D6426F43030003DD41A /* PoolUITests.swift */; };
 		E5B7855A26F720F9006BA633 /* teams.json in Resources */ = {isa = PBXBuildFile; fileRef = E5B7855926F720F9006BA633 /* teams.json */; };
-		E5B7855D26F72152006BA633 /* Team.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B7855C26F72152006BA633 /* Team.swift */; };
+		E5B7855D26F72152006BA633 /* TeamInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B7855C26F72152006BA633 /* TeamInfo.swift */; };
 		E5C03F7927073DE70023E199 /* MoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C03F7827073DE70023E199 /* MoreView.swift */; };
 		E5C03F7B27073F000023E199 /* MoreCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C03F7A27073F000023E199 /* MoreCell.swift */; };
 		E5C03F7E2707435D0023E199 /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C03F7D2707435D0023E199 /* UIView.swift */; };
@@ -62,6 +64,8 @@
 		61D934A52702A08E00AD042C /* DataEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataEntryView.swift; sourceTree = "<group>"; };
 		E50F155E2750B970005D1774 /* sports.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = sports.jpg; sourceTree = "<group>"; };
 		E50F15602750B976005D1774 /* sports2.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = sports2.jpg; sourceTree = "<group>"; };
+		E557A56E275B505E007644FD /* WeeklyCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyCard.swift; sourceTree = "<group>"; };
+		E557A570275B580D007644FD /* Team.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Team.swift; sourceTree = "<group>"; };
 		E5B40D3F26F4302E003DD41A /* Pool.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Pool.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E5B40D4226F4302E003DD41A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E5B40D4426F4302E003DD41A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -76,7 +80,7 @@
 		E5B40D6426F43030003DD41A /* PoolUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoolUITests.swift; sourceTree = "<group>"; };
 		E5B40D6626F43030003DD41A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E5B7855926F720F9006BA633 /* teams.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = teams.json; sourceTree = "<group>"; };
-		E5B7855C26F72152006BA633 /* Team.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Team.swift; sourceTree = "<group>"; };
+		E5B7855C26F72152006BA633 /* TeamInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamInfo.swift; sourceTree = "<group>"; };
 		E5C03F7827073DE70023E199 /* MoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreView.swift; sourceTree = "<group>"; };
 		E5C03F7A27073F000023E199 /* MoreCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreCell.swift; sourceTree = "<group>"; };
 		E5C03F7D2707435D0023E199 /* UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIView.swift; sourceTree = "<group>"; };
@@ -205,7 +209,9 @@
 		E5B7855B26F72140006BA633 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				E5B7855C26F72152006BA633 /* Team.swift */,
+				E557A570275B580D007644FD /* Team.swift */,
+				E5B7855C26F72152006BA633 /* TeamInfo.swift */,
+				E557A56E275B505E007644FD /* WeeklyCard.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -407,13 +413,14 @@
 				E5C3B9522706E925002C1F02 /* MoreViewController.swift in Sources */,
 				6156C0AF271E4A71005FFABE /* DataEntryTableViewController.swift in Sources */,
 				E5C03F892707511A0023E199 /* AnalyticsView.swift in Sources */,
-				E5B7855D26F72152006BA633 /* Team.swift in Sources */,
+				E5B7855D26F72152006BA633 /* TeamInfo.swift in Sources */,
 				61D934A62702A08E00AD042C /* DataEntryView.swift in Sources */,
 				E5C03F872707510B0023E199 /* HomeView.swift in Sources */,
 				61D934A42702A06C00AD042C /* DataEntryViewController.swift in Sources */,
 				E5C03F7E2707435D0023E199 /* UIView.swift in Sources */,
 				E5C3B9502706E91A002C1F02 /* HomeViewController.swift in Sources */,
 				E5DE8BB1274AC326000FE576 /* DataEntryTableView.swift in Sources */,
+				E557A56F275B505E007644FD /* WeeklyCard.swift in Sources */,
 				E5C03F8027074D970023E199 /* AnalyticsViewController.swift in Sources */,
 				E5B40D4726F4302E003DD41A /* ViewController.swift in Sources */,
 				E5C3B94E2706E870002C1F02 /* TabBarController.swift in Sources */,
@@ -422,6 +429,7 @@
 				6156C0B1271E4AB9005FFABE /* DataEntryTableViewCell.swift in Sources */,
 				E5C03F7B27073F000023E199 /* MoreCell.swift in Sources */,
 				E5B40D4326F4302E003DD41A /* AppDelegate.swift in Sources */,
+				E557A571275B580D007644FD /* Team.swift in Sources */,
 				E5B40D4526F4302E003DD41A /* SceneDelegate.swift in Sources */,
 				E5C03F8B270751540023E199 /* ScoresView.swift in Sources */,
 				E5C03F7927073DE70023E199 /* MoreView.swift in Sources */,

--- a/Pool/DataEntry/DataEntryViewController.swift
+++ b/Pool/DataEntry/DataEntryViewController.swift
@@ -14,8 +14,7 @@ class DataEntryViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupView()
-        setupLayout()
-        
+        setupLayout()        
     }
     
     //MARK: - Setup and Layout
@@ -28,6 +27,4 @@ class DataEntryViewController: UIViewController {
     func setupLayout() {
         dataEntryView.addConstraint(topAnchor: view.topAnchor, leadingAnchor: view.leadingAnchor, trailingAnchor: view.trailingAnchor, bottomAnchor: view.bottomAnchor, paddingTop: 70.0, paddingLeft: 0.0, paddingRight: 0.0, paddingBottom: 0.0, width: 0.0, height: 0.0)
     }
-    
-    
 }

--- a/Pool/Models/Team.swift
+++ b/Pool/Models/Team.swift
@@ -2,58 +2,29 @@
 //  Team.swift
 //  Pool
 //
-//  Created by mpc on 9/19/21.
+//  Created by mpc on 12/4/21.
 //
 
 import Foundation
 
 
-
-struct TeamInfo: Codable {
-    var dataOpen: [TeamData]
-    
-    enum CodingKeys: String, CodingKey {
-        case dataOpen = "data"
-    }
-
+struct Team: Codable {
+    let city, name, abr: String
+    let conf: Conf
+    let div: Div
 }
 
-struct TeamData: Codable {
-    var city: String
-    var name: String
-    var abr: String
-    var conf: String
-    var div: String
-    
-    enum CodingKeys: String, CodingKey {
-        case city = "city"
-        case name = "name"
-        case abr = "abr"
-        case conf = "conf"
-        case div = "div"
-    }
-
+enum Conf: String, Codable {
+    case afc = "AFC"
+    case nfc = "NFC"
 }
 
-func ParseJSON () {
-    guard let path = Bundle.main.path(forResource: "teams", ofType: "json") else {
-        return
-    }
-    let url = URL(fileURLWithPath: path)
-    var result: TeamInfo?
-    do {
-        let jsonData = try Data(contentsOf: url)
-        result = try JSONDecoder().decode(TeamInfo.self, from: jsonData)
-        if let result = result {
-            print(result.dataOpen[1].city)
-        }
-        else {
-            print("Failed to parse")
-        }
-        return
-    }
-    catch {
-        print("Error: \(error)")
-    }
+enum Div: String, Codable {
+    case divEast = "East"
+    case east = "EAST"
+    case north = "North"
+    case south = "South"
+    case west = "West"
 }
 
+typealias Teams = [Team]

--- a/Pool/Models/TeamInfo.swift
+++ b/Pool/Models/TeamInfo.swift
@@ -1,0 +1,59 @@
+//
+//  Team.swift
+//  Pool
+//
+//  Created by mpc on 9/19/21.
+//
+
+import Foundation
+
+
+
+struct TeamInfo: Codable {
+    var dataOpen: [TeamData]
+    
+    enum CodingKeys: String, CodingKey {
+        case dataOpen = "data"
+    }
+
+}
+
+struct TeamData: Codable {
+    var city: String
+    var name: String
+    var abr: String
+    var conf: String
+    var div: String
+    
+    enum CodingKeys: String, CodingKey {
+        case city = "city"
+        case name = "name"
+        case abr = "abr"
+        case conf = "conf"
+        case div = "div"
+    }
+
+}
+
+func ParseJSON () {
+    guard let path = Bundle.main.path(forResource: "teams", ofType: "json") else {
+        return
+    }
+    let url = URL(fileURLWithPath: path)
+    var result: TeamInfo?
+    do {
+        let jsonData = try Data(contentsOf: url)
+        result = try JSONDecoder().decode(TeamInfo.self, from: jsonData)
+        if let result = result {
+            print(result.dataOpen[1].city)
+        }
+        else {
+            print("Failed to parse")
+        }
+        return
+    }
+    catch {
+        print("Error: \(error)")
+    }
+}
+

--- a/Pool/Models/WeeklyCard.swift
+++ b/Pool/Models/WeeklyCard.swift
@@ -1,0 +1,32 @@
+//
+//  WeeklyCard.swift
+//  Pool
+//
+//  Created by mpc on 12/4/21.
+//
+
+import Foundation
+
+struct WeeklyCard: Codable {
+    let weekNumber: Int?
+    let teamName: String?
+    let letter: String?
+
+    enum CodingKeys: String, CodingKey {
+        case weekNumber = "weekNumber"
+        case teamName = "teamName"
+        case letter = "letter"
+    }
+
+    init() {
+        self.weekNumber = 0
+        self.teamName = ""
+        self.letter = ""
+    }
+
+    init(weekNumber: Int?, teamName: String?, letter: String?) {
+        self.weekNumber = weekNumber
+        self.teamName = teamName
+        self.letter = letter
+    }
+}


### PR DESCRIPTION
Add WeeklyCard model
Rename Team model to TeamInfo
Restore the Team model to its original

Note: One commit overwrote the Team model with different data.  Undone in this commit.

Changes to be committed:
	modified:   Pool.xcodeproj/project.pbxproj
	modified:   Pool/DataEntry/DataEntryViewController.swift
	modified:   Pool/Models/Team.swift
	new file:   Pool/Models/TeamInfo.swift
	new file:   Pool/Models/WeeklyCard.swift